### PR TITLE
Support both nom_locate 1.0 and 2.0

### DIFF
--- a/nom-packrat/Cargo.toml
+++ b/nom-packrat/Cargo.toml
@@ -20,6 +20,7 @@ pre-release-replacements = [
 
 [dependencies]
 nom_locate         = "1.0.0"
+nom_locate2        = {version = "2.0.0", package = "nom_locate"}
 nom-packrat-macros = {path = "../nom-packrat-macros", version = "^0.3.0"}
 
 [dev-dependencies]

--- a/nom-packrat/src/lib.rs
+++ b/nom-packrat/src/lib.rs
@@ -167,3 +167,12 @@ where
         self.extra.get_extra_state()
     }
 }
+
+impl<T, U, V> HasExtraState<T> for nom_locate2::LocatedSpan<U, V>
+where
+    V: HasExtraState<T>,
+{
+    fn get_extra_state(&self) -> T {
+        self.extra.get_extra_state()
+    }
+}

--- a/nom-packrat/src/lib.rs
+++ b/nom-packrat/src/lib.rs
@@ -159,12 +159,24 @@ impl HasExtraState<()> for &[u8] {
     }
 }
 
+impl<T> HasExtraState<()> for nom_locate::LocatedSpanEx<T, ()> {
+    fn get_extra_state(&self) -> () {
+        ()
+    }
+}
+
 impl<T, U, V> HasExtraState<T> for nom_locate::LocatedSpanEx<U, V>
 where
     V: HasExtraState<T>,
 {
     fn get_extra_state(&self) -> T {
         self.extra.get_extra_state()
+    }
+}
+
+impl<T> HasExtraState<()> for nom_locate2::LocatedSpan<T, ()> {
+    fn get_extra_state(&self) -> () {
+        ()
     }
 }
 


### PR DESCRIPTION
### Added

* Add `HasExtraState` implementation for `LocatedSpan{,Ex}` with `()` extra state.

### Changed

* Support both `nom_locate` 1.0 and 2.0. I'm not sure whether you'd like to keep it this way or drop support for 1.0 altogether.

Closes #1.