### PR TITLE
docs: add link to Wikipedia for packrat parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nom-packrat
-Extension of [nom](https://github.com/Geal/nom) to apply "Packrat Parsing".
+Extension of [nom](https://github.com/Geal/nom) to apply ["Packrat Parsing"](https://en.wikipedia.org/wiki/Parsing_expression_grammar#Implementing_parsers_from_parsing_expression_grammars).
 
 [![Build Status](https://dev.azure.com/dalance/nom-packrat/_apis/build/status/dalance.nom-packrat?branchName=master)](https://dev.azure.com/dalance/nom-packrat/_build/latest?definitionId=1&branchName=master)
 [![Crates.io](https://img.shields.io/crates/v/nom-packrat.svg)](https://crates.io/crates/nom-packrat)


### PR DESCRIPTION
Not everyone knows what "packrat parsing" is, so I added a link to Wikipedia about it. :wink:

Thank you for this library! :heart: I will probably use it in my transpiler, once I switched to nom 5.x (currently 4.x).